### PR TITLE
18 tokenizerfix close with diff quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /**/*.out
 /**/*.a
 minishell
+./test

--- a/src/tokenizer/wordbreaker.c
+++ b/src/tokenizer/wordbreaker.c
@@ -6,7 +6,7 @@
 /*   By: vide-sou <vide-sou@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/21 11:47:15 by vide-sou          #+#    #+#             */
-/*   Updated: 2025/03/26 18:25:23 by vide-sou         ###   ########.fr       */
+/*   Updated: 2025/04/15 13:16:32 by vide-sou         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,13 +55,13 @@ static void     ft_get_first_word(const char *str, int *result)
         if (is_breaker(str[index], 0) && has_open_quote == 0)
             break;
         if ((str[index] == '\'' || str[index] == '\"') && has_open_quote == 0)
-            has_open_quote = 1;
-        else if ((str[index] == '\'' || str[index] == '\"') && has_open_quote == 1)
+            has_open_quote = str[index];
+        else if ((str[index] == has_open_quote) && has_open_quote != 0)
             has_open_quote = 0;
         result[1]++;
         index = result[0] + result[1];
     }
-    if (has_open_quote == 1)
+    if (has_open_quote != 0)
         result[1] = -1;
 }
 

--- a/src/tokenizer/wordbreaker.test.c
+++ b/src/tokenizer/wordbreaker.test.c
@@ -6,7 +6,7 @@
 /*   By: vide-sou <vide-sou@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/21 13:59:02 by vide-sou          #+#    #+#             */
-/*   Updated: 2025/03/26 18:52:37 by vide-sou         ###   ########.fr       */
+/*   Updated: 2025/04/15 13:14:36 by vide-sou         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -175,6 +175,17 @@ Test(wordbreaker, divide_with_escape) {
 Test(wordbreaker, divide_with_quotes_not_complete) {
     const char *input = "comando \"argumento não fechado";
     char *expected[] = {"comando", "argumento não fechado", NULL};
+    char **result = word_breaker(input);
+
+    cr_assert(result == 0);
+}
+
+// Divisão com aspas fechadas de forma incorreta:
+// Entrada: "comando \"argumento não fechado\'"
+// Saída esperada: NULL
+Test(wordbreaker, divide_with_quotes_closed_with_different_quote) {
+    const char *input = "comando \"argumento não fechado\'";
+    char *expected[] = {"comando", "argumento não fechado\'", NULL};
     char **result = word_breaker(input);
 
     cr_assert(result == 0);


### PR DESCRIPTION
Existe um problema na minha lógica inicial para o wordbreaker na hora de trabalhar com aspas, se eu abrir aspas simples eu posso fecha-la com aspas duplas, ou vise-versa posso fechar aspas duplas com aspas simples.

Resolvi verificando qual é a aspas que foi aberta e permitindo só fechar com a mesma.